### PR TITLE
Pin bigquery

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-google-cloud-bigquery = "*"
+google-cloud-bigquery = "==2.30.*"
 matplotlib = "*"
 streamlit-agraph = "*"
 snowflake-connector-python = "*"


### PR DESCRIPTION
Pinning bigquery dependency so as to avoid:
```
from google.cloud.bigquery import _pandas_helpers
...
from db_dtypes import DateDtype, TimeDtype

ModuleNotFoundError: No module named db_types
```